### PR TITLE
Potential fix for code scanning alert no. 7: Incomplete URL substring sanitization

### DIFF
--- a/src/services/GitService.ts
+++ b/src/services/GitService.ts
@@ -537,10 +537,15 @@ export class GitService extends EventEmitter {
   public async isGitHubRepo(): Promise<boolean> {
     try {
       const remotes = await this.getRemotes();
-      return remotes.some(remote => 
-        remote.url.includes('github.com') || 
-        remote.url.includes('github.io')
-      );
+      const allowedHosts = ['github.com', 'github.io'];
+      return remotes.some(remote => {
+        try {
+          const urlHost = new URL(remote.url).host;
+          return allowedHosts.includes(urlHost);
+        } catch {
+          return false; // Invalid URL
+        }
+      });
     } catch (error) {
       console.error('Error checking if repo is a GitHub repo:', error);
       return false;
@@ -553,10 +558,15 @@ export class GitService extends EventEmitter {
   public async getGitHubRepoInfo(): Promise<{ owner: string; repo: string } | null> {
     try {
       const remotes = await this.getRemotes();
-      const githubRemote = remotes.find(remote => 
-        remote.url.includes('github.com') || 
-        remote.url.includes('github.io')
-      );
+      const allowedHosts = ['github.com', 'github.io'];
+      const githubRemote = remotes.find(remote => {
+        try {
+          const urlHost = new URL(remote.url).host;
+          return allowedHosts.includes(urlHost);
+        } catch {
+          return false; // Invalid URL
+        }
+      });
 
       if (!githubRemote) return null;
 


### PR DESCRIPTION
Potential fix for [https://github.com/Leifson1337/lseditor/security/code-scanning/7](https://github.com/Leifson1337/lseditor/security/code-scanning/7)

To fix the issue, we need to parse the URL and validate its host explicitly. Instead of using `includes`, we should extract the host from the URL and compare it against a whitelist of allowed hosts (`github.com` and `github.io`). This ensures that only URLs with these exact hosts (or their subdomains) are considered valid.

The `URL` class in Node.js can be used to parse the URL and extract its host. We will replace the substring checks with a comparison of the parsed host against the allowed hosts.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
